### PR TITLE
fix: adjust span name to also read from `context.path`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -716,7 +716,7 @@ export const opentelemetry = ({
 
 						rootSpan.updateName(
 							// @ts-ignore private property
-							`${method} ${context.route}`
+							`${method} ${context.route || context.path}`
 						)
 						rootSpan.end()
 					})


### PR DESCRIPTION
Fix:
- https://github.com/elysiajs/elysia/issues/1091
- https://github.com/elysiajs/opentelemetry/issues/41

The span name (which should includes the `{method} {path}` fails to read the `path` and returns undefined.

From my observations, the `context.route` is undefined in the recent version changes. This PR address the issue by also conditionally reading from `context.path`.

The reason I still put the `context.route` is for backwards compatibility purposes only.