### PR TITLE
fix: Propagation working incorrectly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -269,12 +269,12 @@ export const opentelemetry = ({
 		name: '@elysia/opentelemetry'
 	})
 		.wrap((fn, request) => {
-			let headers;
+			let headers
 			if (headerHasToJSON) {
-			    // @ts-ignore bun only
-			    headers = request.headers.toJSON()
+				// @ts-ignore bun only
+				headers = request.headers.toJSON()
 			} else {
-			    headers = Object.fromEntries(request.headers.entries())
+				headers = Object.fromEntries(request.headers.entries())
 			}
 
 			const ctx = propagation.extract(otelContext.active(), headers)


### PR DESCRIPTION
Due to some kind of regression in the code, propagation of headers did not work as intended. This was due to passing not the headers object, but the request object, leading to the propagation API not receiving anything.

This fix reverts that change.
