### PR TITLE
Add `checkIfShouldTrace` option to OpenTelemetry plugin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,13 @@ type OpenTeleMetryOptions = NonNullable<
  */
 export interface ElysiaOpenTelemetryOptions extends OpenTeleMetryOptions {
 	contextManager?: ContextManager
+	/**
+	 * Optional function to determine whether a given request should be traced.
+	 *
+	 * @param req - The incoming request object to evaluate.
+	 * @returns A boolean indicating whether tracing should be enabled for this request.
+	 */
+	checkIfShouldTrace?: (req: Request) => boolean
 }
 
 export type ActiveSpanArgs<
@@ -213,6 +220,7 @@ export const opentelemetry = ({
 	serviceName = 'Elysia',
 	instrumentations,
 	contextManager,
+	checkIfShouldTrace,
 	...options
 }: ElysiaOpenTelemetryOptions = {}) => {
 	let tracer = trace.getTracer(serviceName)
@@ -265,9 +273,18 @@ export const opentelemetry = ({
 			// }
 		}
 
-		return new Elysia({
-			name: '@elysia/opentelemetry'
-		}).wrap((fn, request) => {
+	return new Elysia({
+		name: '@elysia/opentelemetry'
+	})
+		.wrap((fn, request) => {
+			const shouldTrace = checkIfShouldTrace
+				? checkIfShouldTrace(request)
+				: true
+
+			if (!shouldTrace) {
+				return fn
+			}
+
 			let headers
 			if (headerHasToJSON) {
 				// @ts-ignore bun only


### PR DESCRIPTION
This PR introduces a new optional function `checkIfShouldTrace` to `ElysiaOpenTelemetryOptions`.  
It allows users to filter out specific requests (e.g., `/health`, `/metrics`) that are typically not useful to trace, reducing noise and overhead in telemetry data.

---

## Changes
- Extended `ElysiaOpenTelemetryOptions` with a new property:
    - `checkIfShouldTrace?: (req: Request) => boolean`

- Wrapped the tracing logic in a conditional that evaluates this function before starting a span.

---

## Updated Interface
    export interface ElysiaOpenTelemetryOptions extends OpenTeleMetryOptions {
      contextManager?: ContextManager
      /**
       * Optional function to determine whether a given request should be traced.
       *
       * @param req - The incoming request object to evaluate.
       * @returns A boolean indicating whether tracing should be enabled for this request.
       */
      checkIfShouldTrace?: (req: Request) => boolean
    }

---

## Example Usage
    import { Elysia } from 'elysia'
    import { OpenTelemetryPlugin } from './otel-plugin'

    const app = new Elysia().use(
      OpenTelemetryPlugin({
        checkIfShouldTrace: (req) => {
          // Skip tracing for health and metrics endpoints
          const url = new URL(req.url)
          return !['/health', '/metrics'].includes(url.pathname)
        }
      })
    )

---

## Benefits
- Allows developers to avoid tracing "noise" endpoints like `/health`, `/metrics`, or static assets.
- Improves performance and reduces unnecessary trace storage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-request tracing control to the OpenTelemetry integration via a new option that lets you decide whether to enable tracing for each request. When disabled for a request, tracing is skipped to reduce overhead.
* **Documentation**
  * Documented the new per-request tracing option with inline comments for easier adoption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->