### PR TITLE
fix: enhance error handling in createActiveSpanHandler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,9 @@ const createActiveSpanHandler = (fn: (span: Span) => unknown) =>
 							message:
 								rejectResult instanceof Error
 									? rejectResult.message
-									: String(rejectResult ?? 'Unknown error')
+									: JSON.stringify(
+											rejectResult ?? 'Unknown error'
+									  )
 						})
 
 						span.recordException(rejectResult)


### PR DESCRIPTION
<img width="1588" height="783" alt="CleanShot 2568-11-18 at 00 13 00 2" src="https://github.com/user-attachments/assets/f1bef83d-e54d-42dc-a73d-12177e3cbbb9" />


<img width="1589" height="866" alt="CleanShot 2568-11-18 at 00 15 32" src="https://github.com/user-attachments/assets/858e0856-a3f3-487a-9d72-113883167ec6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracing and error handling: async and sync failures now consistently mark errors, record exceptions, normalize non-Error rejection values to readable messages, ensure spans are properly ended, and rethrow errors for reliable reporting.

* **Chores**
  * Minor formatting/header-alignment tweaks with no behavioral change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->