### PR TITLE
fix: NodeSDK initialization logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ import {
 	type Attributes,
 	TraceAPI,
 	SpanKind,
-	TracerProvider
+	TracerProvider,
+	ProxyTracerProvider
 } from '@opentelemetry/api'
 
 import { NodeSDK } from '@opentelemetry/sdk-node'
@@ -141,13 +142,10 @@ const isNotEmpty = (obj?: Object) => {
 }
 
 export const shouldStartNodeSDK = (provider: TracerProvider) => {
-	const delegate = (
-		provider as {
-			getDelegate?: () => { constructor?: { name?: string } } | undefined
-		}
-	).getDelegate?.()
-
-	return delegate?.constructor?.name === 'NoopTracerProvider'
+	return (
+		provider instanceof ProxyTracerProvider &&
+		provider.getDelegateTracer('check') === undefined
+	)
 }
 
 export type Tracer = ReturnType<TraceAPI['getTracer']>

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,8 @@ import {
 	type Span,
 	type Attributes,
 	TraceAPI,
-	ProxyTracer,
-	SpanKind
+	SpanKind,
+	TracerProvider
 } from '@opentelemetry/api'
 
 import { NodeSDK } from '@opentelemetry/sdk-node'
@@ -140,6 +140,16 @@ const isNotEmpty = (obj?: Object) => {
 	return false
 }
 
+export const shouldStartNodeSDK = (provider: TracerProvider) => {
+	const delegate = (
+		provider as {
+			getDelegate?: () => { constructor?: { name?: string } } | undefined
+		}
+	).getDelegate?.()
+
+	return delegate?.constructor?.name === 'NoopTracerProvider'
+}
+
 export type Tracer = ReturnType<TraceAPI['getTracer']>
 export type StartSpan = Tracer['startSpan']
 export type StartActiveSpan = Tracer['startActiveSpan']
@@ -238,7 +248,7 @@ export const opentelemetry = ({
 }: ElysiaOpenTelemetryOptions = {}) => {
 	let tracer = trace.getTracer(serviceName)
 
-	if (tracer instanceof ProxyTracer) {
+	if (shouldStartNodeSDK(trace.getTracerProvider())) {
 		const sdk = new NodeSDK({
 			...options,
 			serviceName,

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -20,9 +20,12 @@ describe('Core OpenTelemetry Plugin', () => {
 
 	it('should not start NodeSDK when a delegated tracer provider is already registered', () => {
 		trace.disable()
-		new NodeTracerProvider().register()
-
-		expect(shouldStartNodeSDK(trace.getTracerProvider())).toBe(false)
+		try {
+			new NodeTracerProvider().register()
+			expect(shouldStartNodeSDK(trace.getTracerProvider())).toBe(false)
+		} finally {
+			trace.disable()
+		}
 	})
 
 	it('should initialize plugin without options', () => {

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -4,13 +4,27 @@ import {
 	getTracer,
 	startActiveSpan,
 	setAttributes,
-	getCurrentSpan
+	shouldStartNodeSDK
 } from '../src'
 import { describe, expect, it } from 'bun:test'
-import { trace, SpanStatusCode } from '@opentelemetry/api'
-import { captureSpanData, req } from './test-setup'
+import { trace } from '@opentelemetry/api'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+import { req } from './test-setup'
 
 describe('Core OpenTelemetry Plugin', () => {
+	it('should start NodeSDK when the global tracer provider is still noop', () => {
+		trace.disable()
+
+		expect(shouldStartNodeSDK(trace.getTracerProvider())).toBe(true)
+	})
+
+	it('should not start NodeSDK when a delegated tracer provider is already registered', () => {
+		trace.disable()
+		new NodeTracerProvider().register()
+
+		expect(shouldStartNodeSDK(trace.getTracerProvider())).toBe(false)
+	})
+
 	it('should initialize plugin without options', () => {
 		expect(typeof opentelemetry).toBe('function')
 


### PR DESCRIPTION
## Problem

The current initialization logic checks whether `trace.getTracer(serviceName)` returns a `ProxyTracer`. That is not a reliable signal for whether OpenTelemetry has already been configured, which can cause the plugin to start `NodeSDK` even when a real tracer provider is already registered.

## Changes

- add `shouldStartNodeSDK(provider)` to detect whether the global tracer provider still delegates to `NoopTracerProvider`
- switch plugin initialization to use `trace.getTracerProvider()` instead of checking the tracer instance type
- add tests covering both cases:
  - starts `NodeSDK` when tracing is still noop
  - does not start `NodeSDK` when a real `NodeTracerProvider` is already registered

## Why

This makes SDK startup depend on actual provider state instead of tracer implementation details, which is more accurate and avoids re-initializing OpenTelemetry when the app has already configured it elsewhere.

## Testing

```bash
bun test test/core.test.ts
```

Fixes: https://github.com/elysiajs/opentelemetry/issues/70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added logic to determine whether the Node SDK should auto-start based on the registered tracer provider.

* **Tests**
  * Added test coverage validating startup behavior when no tracer is registered and when a delegated tracer provider is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->