### PR TITLE
Skip redundant child span when lifecycle phase has single hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -382,51 +382,56 @@ export const opentelemetry = ({
 								)
 									return
 
-								onEvent(({ name, onStop }) => {
-									tracer.startActiveSpan(
+							onEvent(({ name, onStop }) => {
+								const useChildSpan = total > 1
+								let span: Span
+								if (useChildSpan) {
+									span = tracer.startSpan(
 										name,
 										{},
-										createContext(event),
-										(span) => {
-											setParent(span)
+										createContext(event)
+									)
+									setParent(span)
+								} else {
+									setParent(event)
+									span = event
+								}
 
-											onStop(({ error }) => {
-												setParent(rootSpan)
+								onStop(({ error }) => {
+										setParent(rootSpan)
 
-												if ((span as any).ended) return
-												if (error) {
-													rootSpan.setStatus({
-														code: SpanStatusCode.ERROR,
-														message: error.message
-													})
+										if ((span as any).ended || (rootSpan as any).ended) return
+										if (error) {
+											rootSpan.setStatus({
+												code: SpanStatusCode.ERROR,
+												message: error.message
+											})
 
-													span.setAttributes({
-														'error.type':
-															error.constructor
-																?.name ??
-															error.name,
-														'error.stack':
-															error.stack
-													})
+											span.setAttributes({
+												'error.type':
+													error.constructor
+														?.name ??
+													error.name,
+												'error.stack':
+													error.stack
+											})
 
-													span.setStatus({
-														code: SpanStatusCode.ERROR,
-														message: error.message
-													})
-												} else {
-													rootSpan.setStatus({
-														code: SpanStatusCode.OK
-													})
+											span.setStatus({
+												code: SpanStatusCode.ERROR,
+												message: error.message
+											})
+										} else {
+											rootSpan.setStatus({
+												code: SpanStatusCode.OK
+											})
 
-													span.setStatus({
-														code: SpanStatusCode.OK
-													})
-												}
-
-												span.end()
+											span.setStatus({
+												code: SpanStatusCode.OK
 											})
 										}
-									)
+
+										if (useChildSpan) span.end()
+									})
 								})
 
 								onStop(() => {

--- a/test/single-hook-span.test.ts
+++ b/test/single-hook-span.test.ts
@@ -1,0 +1,113 @@
+import { Elysia } from 'elysia'
+import { opentelemetry } from '../src'
+import { describe, expect, it } from 'bun:test'
+import { trace } from '@opentelemetry/api'
+import { req } from './test-setup'
+
+describe('Single hook span optimization', () => {
+	it('should not create a child span when a lifecycle phase has a single hook', async () => {
+		const spanNames: string[] = []
+
+		const testApp = new Elysia()
+			.use(opentelemetry({ serviceName: 'single-hook-test' }))
+			.onBeforeHandle(function singleHook() {
+				const span = trace.getActiveSpan()
+				if (span) {
+					// In the single-hook path, the active span should be
+					// the phase group span ("BeforeHandle"), not a child
+					// span named after the hook function
+					spanNames.push(
+						// @ts-ignore — accessing internal name
+						span.name ?? ''
+					)
+				}
+			})
+			.get('/test', () => 'ok')
+
+		await testApp.handle(req('/test'))
+		await new Promise((resolve) => setTimeout(resolve, 100))
+
+		// The active span during a single hook should be "BeforeHandle",
+		// not "singleHook" — because no child span was created
+		expect(spanNames.length).toBeGreaterThan(0)
+		expect(spanNames).not.toContain('singleHook')
+	})
+
+	it('should create child spans when a lifecycle phase has multiple hooks', async () => {
+		const spanNames: string[] = []
+
+		const testApp = new Elysia()
+			.use(opentelemetry({ serviceName: 'multi-hook-test' }))
+			.onBeforeHandle(function hookA() {
+				const span = trace.getActiveSpan()
+				if (span) {
+					spanNames.push(
+						// @ts-ignore
+						span.name ?? ''
+					)
+				}
+			})
+			.onBeforeHandle(function hookB() {
+				const span = trace.getActiveSpan()
+				if (span) {
+					spanNames.push(
+						// @ts-ignore
+						span.name ?? ''
+					)
+				}
+			})
+			.get('/test', () => 'ok')
+
+		await testApp.handle(req('/test'))
+		await new Promise((resolve) => setTimeout(resolve, 100))
+
+		// With multiple hooks, child spans should be created with
+		// the hook function names
+		expect(spanNames).toContain('hookA')
+		expect(spanNames).toContain('hookB')
+	})
+
+	it('should still trace requests correctly with a single hook', async () => {
+		let traceId: string | undefined
+
+		const testApp = new Elysia()
+			.use(opentelemetry({ serviceName: 'single-hook-trace-test' }))
+			.onBeforeHandle(function singleHook() {
+				const span = trace.getActiveSpan()
+				if (span) traceId = span.spanContext().traceId
+			})
+			.get('/test', () => 'ok')
+
+		const response = await testApp.handle(req('/test'))
+		await new Promise((resolve) => setTimeout(resolve, 100))
+
+		expect(response.status).toBe(200)
+		expect(traceId).toBeDefined()
+	})
+
+	it('should handle errors correctly with a single hook', async () => {
+		let errorHandlerCalled = false
+
+		const testApp = new Elysia()
+			.use(opentelemetry({ serviceName: 'single-hook-error-test' }))
+			.onBeforeHandle(function failingHook() {
+				throw new Error('hook failed')
+			})
+			.onError(({ error }) => {
+				errorHandlerCalled = true
+				return {
+					error:
+						error instanceof Error
+							? error.message
+							: String(error)
+				}
+			})
+			.get('/test', () => 'ok')
+
+		const response = await testApp.handle(req('/test'))
+		await new Promise((resolve) => setTimeout(resolve, 100))
+
+		expect(response.status).toBe(500)
+		expect(errorHandlerCalled).toBe(true)
+	})
+})


### PR DESCRIPTION
## Summary

Fixes #73.

When a lifecycle hook (e.g. `BeforeHandle`, `Request`) has only a single handler registered, the plugin currently creates both a hook span **and** a child span wrapping that handler. The child span is redundant — it starts and ends at the exact same time as the hook span, carrying no additional information.

This PR skips creating the child span when `total === 1`, reducing per-request span count. Child spans are still created when a hook has multiple handlers, preserving the ability to distinguish between them.

**Current behavior** — always creates child spans:

```
Root (GET /v1/agents/:slug)
├── BeforeHandle                    ← hook span
│   ├── resolveAuthContext          ← child span (redundant with single handler)
├── Handle
├── Error
│   ├── handleApiError              ← child span (redundant with single handler)
```

**After this PR** — skips redundant child spans:

Single handler:
```
Root (GET /v1/agents/:slug)
├── BeforeHandle                    ← hook span (errors/status recorded here)
├── Handle
├── Error                           ← hook span (errors/status recorded here)
```

Multiple handlers (unchanged):
```
Root (GET /v1/agents/:slug)
├── BeforeHandle                    ← hook span
│   ├── resolveAuthContext          ← child span (handler 1)
│   ├── checkIsSignedIn             ← child span (handler 2)
├── Handle
```

## Implementation approach

Spans are created in two stages before the handlers execute:

1. The **hook span** (e.g. `BeforeHandle`) is created once per hook, before any handlers registered on it run.
2. The **child spans** (e.g. `resolveAuthContext`) are created once per handler, right before it runs. The span wraps the handler and ends when the handler completes.

`total` is known upfront — it is set when the trace reporter is created at compile time. This is the count of handlers registered on that hook, determined when the app starts. Nothing is created and then discarded: `total` is checked before deciding whether to create a child span. When `total === 1`, no child span is ever created.

## Changes

- **`src/index.ts`**: Modified the `inspect` function's `onEvent` handler. When `total === 1`, uses the hook span directly instead of creating a child span. When `total > 1`, creates child spans as before. Error/status handling is shared between both paths.
- **`test/single-hook-span.test.ts`**: Added 4 tests verifying single-handler skips child span, multi-handler creates child spans, tracing works correctly, and error handling propagates.

## Test plan

```bash
bun run build   # builds ESM + CJS
bun run test    # 43 tests pass (4 new + 39 existing), including Node.js CJS/ESM compat
```