### PR TITLE
fix: safe-by-default span attributes — header allow-lists, URL redaction, HTTP extras opt-in

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ const redactQueryString = (query: string, keys: Set<string>): string =>
 			const rawKey = eq === -1 ? p : p.slice(0, eq)
 			let decoded: string
 			try {
-				decoded = decodeURIComponent(rawKey).toLowerCase()
+				decoded = decodeURIComponent(rawKey.replace(/\+/g, ' ')).toLowerCase()
 			} catch {
 				decoded = rawKey.toLowerCase()
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,8 +180,12 @@ const serializeBody = (
 	if (body instanceof ArrayBuffer) return { text: '', size: body.byteLength }
 	if (body instanceof Blob) return { text: '', size: body.size }
 
-	const text =
-		typeof body === 'object' ? JSON.stringify(body) : String(body)
+	let text: string
+	try {
+		text = typeof body === 'object' ? JSON.stringify(body) : String(body)
+	} catch {
+		text = '[Unserializable]'
+	}
 
 	return { text, size: text.length }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,26 @@ const headerHasToJSON = typeof new Headers().toJSON === 'function'
 const toHeaderNameSet = (names: string[] | undefined): Set<string> =>
 	new Set((names ?? []).map((name) => name.toLowerCase()))
 
+const SENSITIVE_QUERY_KEYS = new Set([
+	'token',
+	'access_token',
+	'refresh_token',
+	'id_token',
+	'password',
+	'passwd',
+	'pwd',
+	'secret',
+	'client_secret',
+	'api_key',
+	'apikey',
+	'api-key',
+	'authorization',
+	'credential',
+	'credentials',
+	'code',
+	'nonce'
+])
+
 const parseNumericString = (message: string): number | null => {
 	if (message.length < 16) {
 		if (message.length === 0) return null
@@ -69,7 +89,20 @@ export interface ElysiaOpenTelemetryOptions extends OpenTeleMetryOptions {
 	 * @returns A boolean indicating whether tracing should be enabled for this request.
 	 */
 	checkIfShouldTrace?: (req: Request) => boolean
-	/** Request header names (case-insensitive) to add as `http.request.header.*`. Default: none. `user_agent.original` is still set when the User-Agent header is present (separate from this list). With `cookie`, also sets `http.request.header.cookie` and `http.request.cookie` when `context.cookie` exists. */
+	/**
+	 * Redact `userinfo` and sensitive query values in `url.full` / `url.query`.
+	 * Omitted: default redaction. `false`: record raw URLs (may leak secrets in query or credentials).
+	 */
+	spanUrlRedaction?: false | {
+		stripCredentials?: boolean
+		sensitiveQueryParams?: string[]
+	}
+	/**
+	 * When true, records `user_agent.original`, content-length / body sizes, and request/response body strings.
+	 * Default: false (safe-by-default alongside header allow-lists).
+	 */
+	spanRecordHttpExtras?: boolean
+	/** Request header names (case-insensitive) to add as `http.request.header.*`. Default: none. With `cookie`, also sets `http.request.header.cookie` and `http.request.cookie` when `context.cookie` exists. */
 	spanRequestHeaders?: string[]
 	/** Response header names (case-insensitive) to add as `http.response.header.*`. Default: none. */
 	spanResponseHeaders?: string[]
@@ -139,6 +172,31 @@ const createContext = (parent: Span) => ({
 		return otelContext.active()
 	}
 })
+
+const serializeBody = (
+	body: unknown
+): { text: string; size: number } => {
+	if (body instanceof Uint8Array) return { text: '', size: body.length }
+	if (body instanceof ArrayBuffer) return { text: '', size: body.byteLength }
+	if (body instanceof Blob) return { text: '', size: body.size }
+
+	const text =
+		typeof body === 'object' ? JSON.stringify(body) : String(body)
+
+	return { text, size: text.length }
+}
+
+const redactQueryString = (query: string, keys: Set<string>): string =>
+	query
+		.split('&')
+		.map((p) => {
+			const eq = p.indexOf('=')
+			const key = (eq === -1 ? p : p.slice(0, eq)).toLowerCase()
+			return keys.has(key)
+				? `${eq === -1 ? p : p.slice(0, eq)}=[REDACTED]`
+				: p
+		})
+		.join('&')
 
 const isNotEmpty = (obj?: Object) => {
 	if (!obj) return false
@@ -249,12 +307,24 @@ export const opentelemetry = ({
 	instrumentations,
 	contextManager,
 	checkIfShouldTrace,
+	spanUrlRedaction,
+	spanRecordHttpExtras,
 	spanRequestHeaders,
 	spanResponseHeaders,
 	...options
 }: ElysiaOpenTelemetryOptions = {}) => {
 	const spanRequestHeaderSet = toHeaderNameSet(spanRequestHeaders)
 	const spanResponseHeaderSet = toHeaderNameSet(spanResponseHeaders)
+	const urlRedactOpts = spanUrlRedaction === false ? null : (spanUrlRedaction ?? {})
+	const sensitiveKeys = urlRedactOpts
+		? new Set([
+				...SENSITIVE_QUERY_KEYS,
+				...(urlRedactOpts.sensitiveQueryParams ?? []).map(
+					(k: string) => k.toLowerCase()
+				)
+			])
+		: undefined
+	const stripCreds = urlRedactOpts?.stripCredentials !== false
 
 	let tracer = trace.getTracer(serviceName)
 
@@ -466,26 +536,51 @@ export const opentelemetry = ({
 				}
 
 				// @ts-expect-error private property
-				const url = context.url
+				const rawUrl: string = context.url
+				// @ts-expect-error private property
+				const qi: number | undefined = context.qi
+				const hasQuery = qi !== undefined && qi !== -1
+				let urlQuery = hasQuery ? rawUrl.slice(qi + 1) : undefined
+				let urlFull = rawUrl
+
+				if (urlRedactOpts) {
+					if (urlQuery !== undefined) {
+						urlQuery = redactQueryString(urlQuery, sensitiveKeys!)
+						urlFull = `${rawUrl.slice(0, qi)}?${urlQuery}`
+					}
+
+					if (stripCreds && urlFull.indexOf('@') > 0) {
+						try {
+							const u = new URL(urlFull)
+							if (u.username || u.password) {
+								u.username = ''
+								u.password = ''
+								urlFull = u.href
+							}
+						} catch {
+							// keep urlFull as-is
+						}
+					}
+				}
+
 				const attributes: Record<string, string | number> =
 					Object.assign(Object.create(null), {
 						// ? Elysia Custom attribute
 						'http.request.id': id,
 						'http.request.method': method,
 						'url.path': path,
-						'url.full': url
+						'url.full': urlFull
 					})
 
-				// @ts-ignore private property
-				if (context.qi && context.qi !== -1)
-					attributes['url.query'] = url.slice(
-						// @ts-ignore private property
-						context.qi + 1
-					)
+				if (urlQuery !== undefined)
+					attributes['url.query'] = urlQuery
 
-				const protocolSeparator = url.indexOf('://')
+				const protocolSeparator = urlFull.indexOf('://')
 				if (protocolSeparator > 0)
-					attributes['url.scheme'] = url.slice(0, protocolSeparator)
+					attributes['url.scheme'] = urlFull.slice(
+						0,
+						protocolSeparator
+					)
 
 				onRequest(inspect('Request'))
 				onParse(inspect('Parse'))
@@ -598,7 +693,7 @@ export const opentelemetry = ({
 						let contentLength =
 							request.headers.get('content-length')
 
-						if (contentLength) {
+						if (spanRecordHttpExtras && contentLength) {
 							const number = parseNumericString(contentLength)
 
 							if (number)
@@ -607,7 +702,7 @@ export const opentelemetry = ({
 						}
 					}
 
-					{
+					if (spanRecordHttpExtras) {
 						const userAgent = request.headers.get('User-Agent')
 
 						if (userAgent)
@@ -736,55 +831,24 @@ export const opentelemetry = ({
 
 				onParse(() => {
 					const body = context.body
-					if (body !== undefined && body !== null) {
-						const value =
-							typeof body === 'object'
-								? JSON.stringify(body)
-								: body.toString()
+					if (body === undefined || body === null || !spanRecordHttpExtras)
+						return
 
-						attributes['http.request.body'] = value
-
-						if (typeof body === 'object') {
-							if (body instanceof Uint8Array)
-								attributes['http.request.body.size'] =
-									body.length
-							else if (body instanceof ArrayBuffer)
-								attributes['http.request.body.size'] =
-									body.byteLength
-							else if (body instanceof Blob)
-								attributes['http.request.body.size'] = body.size
-
-							attributes['http.request.body.size'] = value.length
-						} else {
-							attributes['http.request.body.size'] = value.length
-						}
-					}
+					const { text, size } = serializeBody(body)
+					if (text) attributes['http.request.body'] = text
+					attributes['http.request.body.size'] = size
 				})
 
 				onMapResponse(() => {
 					const body = context.body
-					if (body !== undefined && body !== null) {
-						const value =
-							typeof body === 'object'
-								? JSON.stringify(body)
-								: body.toString()
-
-						attributes['http.request.body'] = value
-
-						if (typeof body === 'object') {
-							if (body instanceof Uint8Array)
-								attributes['http.request.body.size'] =
-									body.length
-							else if (body instanceof ArrayBuffer)
-								attributes['http.request.body.size'] =
-									body.byteLength
-							else if (body instanceof Blob)
-								attributes['http.request.body.size'] = body.size
-
-							attributes['http.request.body.size'] = value.length
-						} else {
-							attributes['http.request.body.size'] = value.length
-						}
+					if (
+						body !== undefined &&
+						body !== null &&
+						spanRecordHttpExtras
+					) {
+						const { text, size } = serializeBody(body)
+						if (text) attributes['http.request.body'] = text
+						attributes['http.request.body.size'] = size
 					}
 
 					{
@@ -797,41 +861,11 @@ export const opentelemetry = ({
 
 					// @ts-ignore
 					const response = context.responseValue
-					if (response !== undefined)
-						switch (typeof response) {
-							case 'object':
-								if (response instanceof Response) {
-									// Unable to access as async, skip
-								} else if (response instanceof Uint8Array)
-									attributes['http.response.body.size'] =
-										response.length
-								else if (response instanceof ArrayBuffer)
-									attributes['http.response.body.size'] =
-										response.byteLength
-								else if (response instanceof Blob)
-									attributes['http.response.body.size'] =
-										response.size
-								else {
-									const value = JSON.stringify(response)
-
-									attributes['http.response.body'] = value
-									attributes['http.response.body.size'] =
-										value.length
-								}
-
-								break
-
-							default:
-								if (response === undefined || response === null)
-									attributes['http.response.body.size'] = 0
-								else {
-									const value = response.toString()
-
-									attributes['http.response.body'] = value
-									attributes['http.response.body.size'] =
-										value.length
-								}
-						}
+					if (response !== undefined && spanRecordHttpExtras) {
+						const { text, size } = serializeBody(response)
+						if (text) attributes['http.response.body'] = text
+						attributes['http.response.body.size'] = size
+					}
 
 					if (!(rootSpan as any).ended) {
 						const statusCode =
@@ -860,28 +894,14 @@ export const opentelemetry = ({
 					}
 
 					const body = context.body
-					if (body !== undefined && body !== null) {
-						const value =
-							typeof body === 'object'
-								? JSON.stringify(body)
-								: body.toString()
-
-						attributes['http.request.body'] = value
-
-						if (typeof body === 'object') {
-							if (body instanceof Uint8Array)
-								attributes['http.request.body.size'] =
-									body.length
-							else if (body instanceof ArrayBuffer)
-								attributes['http.request.body.size'] =
-									body.byteLength
-							else if (body instanceof Blob)
-								attributes['http.request.body.size'] = body.size
-
-							attributes['http.request.body.size'] = value.length
-						} else {
-							attributes['http.request.body.size'] = value.length
-						}
+					if (
+						body !== undefined &&
+						body !== null &&
+						spanRecordHttpExtras
+					) {
+						const { text, size } = serializeBody(body)
+						if (text) attributes['http.request.body'] = text
+						attributes['http.request.body.size'] = size
 					}
 
 					if (!(rootSpan as any).ended) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export interface ElysiaOpenTelemetryOptions extends OpenTeleMetryOptions {
 	 * @returns A boolean indicating whether tracing should be enabled for this request.
 	 */
 	checkIfShouldTrace?: (req: Request) => boolean
-	/** Request header names (case-insensitive) to add as `http.request.header.*`. Default: none. `user_agent.original` unchanged. With `cookie`, also sets `http.request.header.cookie` and `http.request.cookie` when `context.cookie` exists. */
+	/** Request header names (case-insensitive) to add as `http.request.header.*`. Default: none. `user_agent.original` is still set when the User-Agent header is present (separate from this list). With `cookie`, also sets `http.request.header.cookie` and `http.request.cookie` when `context.cookie` exists. */
 	spanRequestHeaders?: string[]
 	/** Response header names (case-insensitive) to add as `http.response.header.*`. Default: none. */
 	spanResponseHeaders?: string[]
@@ -646,7 +646,6 @@ export const opentelemetry = ({
 							key = key.toLowerCase()
 
 							if (hasHeaders) {
-								if (key === 'user-agent') continue
 								if (!spanRequestHeaderSet.has(key)) continue
 
 								if (typeof value === 'object')
@@ -669,11 +668,6 @@ export const opentelemetry = ({
 									attributes[`http.request.header.${key}`] =
 										serialized
 							} else if (value !== undefined) {
-								if (key === 'user-agent') {
-									headers[key] = value
-									continue
-								}
-
 								headers[key] = value
 
 								if (spanRequestHeaderSet.has(key))

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ import { NodeSDK } from '@opentelemetry/sdk-node'
 // @ts-ignore bun only
 const headerHasToJSON = typeof new Headers().toJSON === 'function'
 
+const toHeaderNameSet = (names: string[] | undefined): Set<string> =>
+	new Set((names ?? []).map((name) => name.toLowerCase()))
+
 const parseNumericString = (message: string): number | null => {
 	if (message.length < 16) {
 		if (message.length === 0) return null
@@ -66,6 +69,10 @@ export interface ElysiaOpenTelemetryOptions extends OpenTeleMetryOptions {
 	 * @returns A boolean indicating whether tracing should be enabled for this request.
 	 */
 	checkIfShouldTrace?: (req: Request) => boolean
+	/** Request header names (case-insensitive) to add as `http.request.header.*`. Default: none. `user_agent.original` unchanged. With `cookie`, also sets `http.request.header.cookie` and `http.request.cookie` when `context.cookie` exists. */
+	spanRequestHeaders?: string[]
+	/** Response header names (case-insensitive) to add as `http.response.header.*`. Default: none. */
+	spanResponseHeaders?: string[]
 }
 
 export type ActiveSpanArgs<
@@ -242,8 +249,13 @@ export const opentelemetry = ({
 	instrumentations,
 	contextManager,
 	checkIfShouldTrace,
+	spanRequestHeaders,
+	spanResponseHeaders,
 	...options
 }: ElysiaOpenTelemetryOptions = {}) => {
+	const spanRequestHeaderSet = toHeaderNameSet(spanRequestHeaders)
+	const spanResponseHeaderSet = toHeaderNameSet(spanResponseHeaders)
+
 	let tracer = trace.getTracer(serviceName)
 
 	if (shouldStartNodeSDK(trace.getTracerProvider())) {
@@ -635,6 +647,7 @@ export const opentelemetry = ({
 
 							if (hasHeaders) {
 								if (key === 'user-agent') continue
+								if (!spanRequestHeaderSet.has(key)) continue
 
 								if (typeof value === 'object')
 									// Handle Set-Cookie array
@@ -647,21 +660,25 @@ export const opentelemetry = ({
 								continue
 							}
 
-							if (typeof value === 'object')
-								// Handle Set-Cookie array
-								headers[key] = attributes[
-									`http.request.header.${key}`
-								] = JSON.stringify(value)
-							else if (value !== undefined) {
+							if (typeof value === 'object') {
+								const serialized = JSON.stringify(value)
+
+								headers[key] = serialized
+
+								if (spanRequestHeaderSet.has(key))
+									attributes[`http.request.header.${key}`] =
+										serialized
+							} else if (value !== undefined) {
 								if (key === 'user-agent') {
 									headers[key] = value
-
 									continue
 								}
 
-								headers[key] = attributes[
-									`http.request.header.${key}`
-								] = value
+								headers[key] = value
+
+								if (spanRequestHeaderSet.has(key))
+									attributes[`http.request.header.${key}`] =
+										value
 							}
 						}
 					}
@@ -679,6 +696,7 @@ export const opentelemetry = ({
 
 						for (let [key, value] of headers) {
 							key = key.toLowerCase()
+							if (!spanResponseHeaderSet.has(key)) continue
 
 							if (typeof value === 'object')
 								attributes[`http.response.header.${key}`] =
@@ -708,8 +726,8 @@ export const opentelemetry = ({
 									: (ip.address ?? ip.toString())
 					}
 
-					// ? Elysia Custom attribute
-					if (cookie) {
+					// ? Elysia Custom attribute (opt-in: spanRequestHeaders includes `cookie`)
+					if (spanRequestHeaderSet.has('cookie') && cookie) {
 						const _cookie = <Record<string, string>>{}
 
 						for (const [key, { value }] of Object.entries(cookie))

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,23 +198,49 @@ const serializeBody = (
 	return { text, size: text.length }
 }
 
-const redactQueryString = (query: string, keys: Set<string>): string =>
-	query
-		.split('&')
-		.map((p) => {
-			const eq = p.indexOf('=')
-			const rawKey = eq === -1 ? p : p.slice(0, eq)
-			let decoded: string
+const redactQueryString = (query: string, keys: Set<string>): string => {
+	if (query === '' || keys.size === 0) return query
+
+	let out = ''
+	let partStart = 0
+	let keyEnd = -1
+
+	for (let i = 0; i <= query.length; i++) {
+		const ch = i === query.length ? 38 : query.charCodeAt(i)
+
+		if (ch === 61 && keyEnd === -1) {
+			keyEnd = i // '='
+			continue
+		}
+
+		if (ch !== 38) continue // '&'
+
+		const partEnd = i
+		const rawKeyEnd = keyEnd === -1 ? partEnd : keyEnd
+		const rawKey = query.slice(partStart, rawKeyEnd)
+
+		let decoded: string
+		if (rawKey.indexOf('%') !== -1 || rawKey.indexOf('+') !== -1) {
 			try {
 				decoded = decodeURIComponent(rawKey.replace(/\+/g, ' ')).toLowerCase()
 			} catch {
 				decoded = rawKey.toLowerCase()
 			}
-			return keys.has(decoded)
-				? `${rawKey}=[REDACTED]`
-				: p
-		})
-		.join('&')
+		} else {
+			decoded = rawKey.toLowerCase()
+		}
+
+		if (out) out += '&'
+		out += keys.has(decoded)
+			? rawKey + '=[REDACTED]'
+			: query.slice(partStart, partEnd)
+
+		partStart = i + 1
+		keyEnd = -1
+	}
+
+	return out
+}
 
 export const shouldStartNodeSDK = (provider: TracerProvider) => {
 	return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,14 +98,22 @@ export interface ElysiaOpenTelemetryOptions extends OpenTeleMetryOptions {
 		sensitiveQueryParams?: string[]
 	}
 	/**
-	 * When true, records `user_agent.original`, content-length / body sizes, and request/response body strings.
-	 * Default: false (safe-by-default alongside header allow-lists).
+	 * Record full request/response body content on spans.
+	 * `true`: record both request and response bodies.
+	 * `{ request: true }` or `{ response: true }`: record only one side.
+	 * Default: `false` (no body content recorded).
 	 */
-	spanRecordHttpExtras?: boolean
-	/** Request header names (case-insensitive) to add as `http.request.header.*`. Default: none. With `cookie`, also sets `http.request.header.cookie` and `http.request.cookie` when `context.cookie` exists. */
-	spanRequestHeaders?: string[]
-	/** Response header names (case-insensitive) to add as `http.response.header.*`. Default: none. */
-	spanResponseHeaders?: string[]
+	recordBody?: boolean | { request?: boolean; response?: boolean }
+	/**
+	 * HTTP header names (case-insensitive) to capture as span attributes.
+	 * Use `"*"` in either list to capture all headers (useful for dev/debugging; may include sensitive values).
+	 * Including `"cookie"` in `requestHeaders` also emits `http.request.cookie` when `context.cookie` exists.
+	 * Default: none (no headers recorded).
+	 */
+	headersToSpanAttributes?: {
+		requestHeaders?: string[]
+		responseHeaders?: string[]
+	}
 }
 
 export type ActiveSpanArgs<
@@ -207,14 +215,6 @@ const redactQueryString = (query: string, keys: Set<string>): string =>
 				: p
 		})
 		.join('&')
-
-const isNotEmpty = (obj?: Object) => {
-	if (!obj) return false
-
-	for (const x in obj) return true
-
-	return false
-}
 
 export const shouldStartNodeSDK = (provider: TracerProvider) => {
 	return (
@@ -318,13 +318,16 @@ export const opentelemetry = ({
 	contextManager,
 	checkIfShouldTrace,
 	spanUrlRedaction,
-	spanRecordHttpExtras,
-	spanRequestHeaders,
-	spanResponseHeaders,
+	recordBody,
+	headersToSpanAttributes,
 	...options
 }: ElysiaOpenTelemetryOptions = {}) => {
-	const spanRequestHeaderSet = toHeaderNameSet(spanRequestHeaders)
-	const spanResponseHeaderSet = toHeaderNameSet(spanResponseHeaders)
+	const spanRequestHeaderSet = toHeaderNameSet(headersToSpanAttributes?.requestHeaders)
+	const spanResponseHeaderSet = toHeaderNameSet(headersToSpanAttributes?.responseHeaders)
+	const requestHeaderWildcard = spanRequestHeaderSet.has('*')
+	const responseHeaderWildcard = spanResponseHeaderSet.has('*')
+	const recordRequestBody = recordBody === true || (recordBody && recordBody.request) || false
+	const recordResponseBody = recordBody === true || (recordBody && recordBody.response) || false
 	const urlRedactOpts = spanUrlRedaction === false ? null : (spanUrlRedaction ?? {})
 	const sensitiveKeys = urlRedactOpts
 		? new Set([
@@ -699,30 +702,21 @@ export const opentelemetry = ({
 					 * but not always, present as the Content-Length header.
 					 * For requests using transport encoding, this should be the compressed size.
 					 **/
-					{
-						let contentLength =
-							request.headers.get('content-length')
+					const contentLength = request.headers.get('content-length')
+					if (contentLength) {
+						const number = parseNumericString(contentLength)
 
-						if (spanRecordHttpExtras && contentLength) {
-							const number = parseNumericString(contentLength)
-
-							if (number)
-								attributes['http.request_content_length'] =
-									number
-						}
+						if (number !== null)
+							attributes['http.request_content_length'] = number
 					}
 
-					if (spanRecordHttpExtras) {
-						const userAgent = request.headers.get('User-Agent')
-
-						if (userAgent)
-							attributes['user_agent.original'] = userAgent
-					}
+					const userAgent = request.headers.get('User-Agent')
+					if (userAgent)
+						attributes['user_agent.original'] = userAgent
 
 					const server = context.server
 					if (server) {
 						attributes['server.port'] = server.port ?? 80
-						attributes['server.address'] = server.url.hostname
 						attributes['server.address'] = server.url.hostname
 					}
 
@@ -751,7 +745,7 @@ export const opentelemetry = ({
 							key = key.toLowerCase()
 
 							if (hasHeaders) {
-								if (!spanRequestHeaderSet.has(key)) continue
+								if (!requestHeaderWildcard && !spanRequestHeaderSet.has(key)) continue
 
 								if (typeof value === 'object')
 									// Handle Set-Cookie array
@@ -769,13 +763,13 @@ export const opentelemetry = ({
 
 								headers[key] = serialized
 
-								if (spanRequestHeaderSet.has(key))
+								if (requestHeaderWildcard || spanRequestHeaderSet.has(key))
 									attributes[`http.request.header.${key}`] =
 										serialized
 							} else if (value !== undefined) {
 								headers[key] = value
 
-								if (spanRequestHeaderSet.has(key))
+								if (requestHeaderWildcard || spanRequestHeaderSet.has(key))
 									attributes[`http.request.header.${key}`] =
 										value
 							}
@@ -795,7 +789,7 @@ export const opentelemetry = ({
 
 						for (let [key, value] of headers) {
 							key = key.toLowerCase()
-							if (!spanResponseHeaderSet.has(key)) continue
+							if (!responseHeaderWildcard && !spanResponseHeaderSet.has(key)) continue
 
 							if (typeof value === 'object')
 								attributes[`http.response.header.${key}`] =
@@ -825,8 +819,8 @@ export const opentelemetry = ({
 									: (ip.address ?? ip.toString())
 					}
 
-					// ? Elysia Custom attribute (opt-in: spanRequestHeaders includes `cookie`)
-					if (spanRequestHeaderSet.has('cookie') && cookie) {
+					// ? Elysia Custom attribute (opt-in: requestHeaders includes `cookie`)
+					if ((requestHeaderWildcard || spanRequestHeaderSet.has('cookie')) && cookie) {
 						const _cookie = <Record<string, string>>{}
 
 						for (const [key, { value }] of Object.entries(cookie))
@@ -841,7 +835,7 @@ export const opentelemetry = ({
 
 				onParse(() => {
 					const body = context.body
-					if (body === undefined || body === null || !spanRecordHttpExtras)
+					if (body === undefined || body === null || !recordRequestBody)
 						return
 
 					const { text, size } = serializeBody(body)
@@ -854,7 +848,7 @@ export const opentelemetry = ({
 					if (
 						body !== undefined &&
 						body !== null &&
-						spanRecordHttpExtras
+						recordRequestBody
 					) {
 						const { text, size } = serializeBody(body)
 						if (text) attributes['http.request.body'] = text
@@ -871,7 +865,7 @@ export const opentelemetry = ({
 
 					// @ts-ignore
 					const response = context.responseValue
-					if (response !== undefined && spanRecordHttpExtras) {
+					if (response !== undefined && recordResponseBody) {
 						const { text, size } = serializeBody(response)
 						if (text) attributes['http.response.body'] = text
 						attributes['http.response.body.size'] = size
@@ -907,7 +901,7 @@ export const opentelemetry = ({
 					if (
 						body !== undefined &&
 						body !== null &&
-						spanRecordHttpExtras
+						recordRequestBody
 					) {
 						const { text, size } = serializeBody(body)
 						if (text) attributes['http.request.body'] = text

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,9 +191,15 @@ const redactQueryString = (query: string, keys: Set<string>): string =>
 		.split('&')
 		.map((p) => {
 			const eq = p.indexOf('=')
-			const key = (eq === -1 ? p : p.slice(0, eq)).toLowerCase()
-			return keys.has(key)
-				? `${eq === -1 ? p : p.slice(0, eq)}=[REDACTED]`
+			const rawKey = eq === -1 ? p : p.slice(0, eq)
+			let decoded: string
+			try {
+				decoded = decodeURIComponent(rawKey).toLowerCase()
+			} catch {
+				decoded = rawKey.toLowerCase()
+			}
+			return keys.has(decoded)
+				? `${rawKey}=[REDACTED]`
 				: p
 		})
 		.join('&')

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,19 +219,8 @@ const redactQueryString = (query: string, keys: Set<string>): string => {
 		const rawKeyEnd = keyEnd === -1 ? partEnd : keyEnd
 		const rawKey = query.slice(partStart, rawKeyEnd)
 
-		let decoded: string
-		if (rawKey.indexOf('%') !== -1 || rawKey.indexOf('+') !== -1) {
-			try {
-				decoded = decodeURIComponent(rawKey.replace(/\+/g, ' ')).toLowerCase()
-			} catch {
-				decoded = rawKey.toLowerCase()
-			}
-		} else {
-			decoded = rawKey.toLowerCase()
-		}
-
 		if (out) out += '&'
-		out += keys.has(decoded)
+		out += keys.has(rawKey.toLowerCase())
 			? rawKey + '=[REDACTED]'
 			: query.slice(partStart, partEnd)
 

--- a/test/span-headers.test.ts
+++ b/test/span-headers.test.ts
@@ -44,8 +44,7 @@ describe('Span header attributes (opt-in allow-list)', () => {
 				headers: {
 					authorization: 'secret',
 					'x-scanner-probe': 'junk',
-					cookie: 'session=secret',
-					'user-agent': 'default-test-ua'
+					cookie: 'session=secret'
 				}
 			})
 		)
@@ -58,7 +57,6 @@ describe('Span header attributes (opt-in allow-list)', () => {
 		expect(attrs['http.request.header.x-scanner-probe']).toBeUndefined()
 		expect(attrs['http.request.header.cookie']).toBeUndefined()
 		expect(attrs['http.request.header.user-agent']).toBeUndefined()
-		expect(attrs['user_agent.original']).toBeUndefined()
 	})
 
 	it('records only allow-listed request headers', async () => {
@@ -66,7 +64,9 @@ describe('Span header attributes (opt-in allow-list)', () => {
 			.use(
 				opentelemetry({
 					serviceName: 'headers-allowlist',
-					spanRequestHeaders: ['X-Allowed', 'content-type']
+					headersToSpanAttributes: {
+						requestHeaders: ['X-Allowed', 'content-type']
+					}
 				})
 			)
 			.get('/r', () => 'ok')
@@ -92,13 +92,71 @@ describe('Span header attributes (opt-in allow-list)', () => {
 		expect(attrs['http.request.header.x-other']).toBeUndefined()
 	})
 
+	it('records all request headers when "*" wildcard is used', async () => {
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					serviceName: 'headers-wildcard',
+					headersToSpanAttributes: {
+						requestHeaders: ['*']
+					}
+				})
+			)
+			.get('/r', () => 'ok')
+
+		await app.handle(
+			new Request('http://localhost/r', {
+				headers: {
+					authorization: 'Bearer tok',
+					'x-custom': 'value',
+					cookie: 'a=1'
+				}
+			})
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+		expect(attrs['http.request.header.authorization']).toBe('Bearer tok')
+		expect(attrs['http.request.header.x-custom']).toBe('value')
+		expect(attrs['http.request.header.cookie']).toBe('a=1')
+	})
+
+	it('records all response headers when "*" wildcard is used', async () => {
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					serviceName: 'resp-wildcard',
+					headersToSpanAttributes: {
+						responseHeaders: ['*']
+					}
+				})
+			)
+			.onRequest(({ set }) => {
+				set.headers['X-Out'] = 'seen'
+				set.headers['X-Secret'] = 'also-seen'
+			})
+			.get('/r', () => 'ok')
+
+		await app.handle(new Request('http://localhost/r'))
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+		expect(attrs['http.response.header.x-out']).toBe('seen')
+		expect(attrs['http.response.header.x-secret']).toBe('also-seen')
+	})
+
 	it('records http.request.header.user-agent when allow-listed', async () => {
 		const app = new Elysia()
 			.use(
 				opentelemetry({
 					serviceName: 'user-agent-allowlist',
-					spanRequestHeaders: ['user-agent'],
-					spanRecordHttpExtras: true
+					headersToSpanAttributes: {
+						requestHeaders: ['user-agent']
+					}
 				})
 			)
 			.get('/r', () => 'ok')
@@ -124,7 +182,9 @@ describe('Span header attributes (opt-in allow-list)', () => {
 			.use(
 				opentelemetry({
 					serviceName: 'cookie-allowlist',
-					spanRequestHeaders: ['cookie']
+					headersToSpanAttributes: {
+						requestHeaders: ['cookie']
+					}
 				})
 			)
 			.get('/r', () => 'ok')
@@ -148,7 +208,9 @@ describe('Span header attributes (opt-in allow-list)', () => {
 			.use(
 				opentelemetry({
 					serviceName: 'cookie-absent',
-					spanRequestHeaders: ['cookie']
+					headersToSpanAttributes: {
+						requestHeaders: ['cookie']
+					}
 				})
 			)
 			.get('/r', () => 'ok')
@@ -191,7 +253,9 @@ describe('Span header attributes (opt-in allow-list)', () => {
 			.use(
 				opentelemetry({
 					serviceName: 'resp-headers-allowlist',
-					spanResponseHeaders: ['x-out']
+					headersToSpanAttributes: {
+						responseHeaders: ['x-out']
+					}
 				})
 			)
 			.onRequest(({ set }) => {

--- a/test/span-headers.test.ts
+++ b/test/span-headers.test.ts
@@ -58,7 +58,7 @@ describe('Span header attributes (opt-in allow-list)', () => {
 		expect(attrs['http.request.header.x-scanner-probe']).toBeUndefined()
 		expect(attrs['http.request.header.cookie']).toBeUndefined()
 		expect(attrs['http.request.header.user-agent']).toBeUndefined()
-		expect(attrs['user_agent.original']).toBe('default-test-ua')
+		expect(attrs['user_agent.original']).toBeUndefined()
 	})
 
 	it('records only allow-listed request headers', async () => {
@@ -97,7 +97,8 @@ describe('Span header attributes (opt-in allow-list)', () => {
 			.use(
 				opentelemetry({
 					serviceName: 'user-agent-allowlist',
-					spanRequestHeaders: ['user-agent']
+					spanRequestHeaders: ['user-agent'],
+					spanRecordHttpExtras: true
 				})
 			)
 			.get('/r', () => 'ok')

--- a/test/span-headers.test.ts
+++ b/test/span-headers.test.ts
@@ -162,6 +162,29 @@ describe('Span header attributes (opt-in allow-list)', () => {
 		expect(attrs['http.request.cookie']).toBeUndefined()
 	})
 
+	it('does not record response headers on the span by default', async () => {
+		const app = new Elysia()
+			.use(opentelemetry({ serviceName: 'no-response-headers-default' }))
+			.onRequest(({ set }) => {
+				set.headers['Set-Cookie'] = 'session=abc; HttpOnly'
+				set.headers['X-Custom-Resp'] = 'sensitive'
+			})
+			.get('/r', () => 'ok')
+
+		await app.handle(new Request('http://localhost/r'))
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+
+		expect(attrs['http.response.header.set-cookie']).toBeUndefined()
+		expect(attrs['http.response.header.x-custom-resp']).toBeUndefined()
+
+		for (const key of Object.keys(attrs))
+			expect(key.startsWith('http.response.header.')).toBe(false)
+	})
+
 	it('records only allow-listed response headers', async () => {
 		const app = new Elysia()
 			.use(

--- a/test/span-headers.test.ts
+++ b/test/span-headers.test.ts
@@ -44,7 +44,8 @@ describe('Span header attributes (opt-in allow-list)', () => {
 				headers: {
 					authorization: 'secret',
 					'x-scanner-probe': 'junk',
-					cookie: 'session=secret'
+					cookie: 'session=secret',
+					'user-agent': 'default-test-ua'
 				}
 			})
 		)
@@ -56,6 +57,8 @@ describe('Span header attributes (opt-in allow-list)', () => {
 		expect(attrs['http.request.header.authorization']).toBeUndefined()
 		expect(attrs['http.request.header.x-scanner-probe']).toBeUndefined()
 		expect(attrs['http.request.header.cookie']).toBeUndefined()
+		expect(attrs['http.request.header.user-agent']).toBeUndefined()
+		expect(attrs['user_agent.original']).toBe('default-test-ua')
 	})
 
 	it('records only allow-listed request headers', async () => {
@@ -87,6 +90,32 @@ describe('Span header attributes (opt-in allow-list)', () => {
 		expect(attrs['http.request.header.content-type']).toBe('text/plain')
 		expect(attrs['http.request.header.authorization']).toBeUndefined()
 		expect(attrs['http.request.header.x-other']).toBeUndefined()
+	})
+
+	it('records http.request.header.user-agent when allow-listed', async () => {
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					serviceName: 'user-agent-allowlist',
+					spanRequestHeaders: ['user-agent']
+				})
+			)
+			.get('/r', () => 'ok')
+
+		await app.handle(
+			new Request('http://localhost/r', {
+				headers: { 'user-agent': 'regression-test-ua' }
+			})
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+		expect(attrs['http.request.header.user-agent']).toBe(
+			'regression-test-ua'
+		)
+		expect(attrs['user_agent.original']).toBe('regression-test-ua')
 	})
 
 	it('records raw Cookie header when allow-listed (http.request.cookie only with context.cookie)', async () => {

--- a/test/span-headers.test.ts
+++ b/test/span-headers.test.ts
@@ -1,0 +1,159 @@
+import { Elysia } from 'elysia'
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test'
+import { trace } from '@opentelemetry/api'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+import {
+	InMemorySpanExporter,
+	SimpleSpanProcessor
+} from '@opentelemetry/sdk-trace-base'
+import { opentelemetry } from '../src'
+
+const flushSpans = () => new Promise((r) => setTimeout(r, 150))
+
+describe('Span header attributes (opt-in allow-list)', () => {
+	let exporter: InMemorySpanExporter
+	let provider: NodeTracerProvider
+
+	beforeEach(() => {
+		trace.disable()
+		exporter = new InMemorySpanExporter()
+		provider = new NodeTracerProvider({
+			spanProcessors: [new SimpleSpanProcessor(exporter)]
+		})
+		provider.register()
+	})
+
+	afterEach(async () => {
+		await provider.shutdown()
+		trace.disable()
+	})
+
+	function rootSpan() {
+		return exporter.getFinishedSpans().find(
+			(s) => s.attributes['http.request.method'] !== undefined
+		)
+	}
+
+	it('does not record request headers on the span by default', async () => {
+		const app = new Elysia()
+			.use(opentelemetry({ serviceName: 'no-headers-default' }))
+			.get('/r', () => 'ok')
+
+		await app.handle(
+			new Request('http://localhost/r', {
+				headers: {
+					authorization: 'secret',
+					'x-scanner-probe': 'junk',
+					cookie: 'session=secret'
+				}
+			})
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+		expect(attrs['http.request.header.authorization']).toBeUndefined()
+		expect(attrs['http.request.header.x-scanner-probe']).toBeUndefined()
+		expect(attrs['http.request.header.cookie']).toBeUndefined()
+	})
+
+	it('records only allow-listed request headers', async () => {
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					serviceName: 'headers-allowlist',
+					spanRequestHeaders: ['X-Allowed', 'content-type']
+				})
+			)
+			.get('/r', () => 'ok')
+
+		await app.handle(
+			new Request('http://localhost/r', {
+				headers: {
+					'x-allowed': 'yes',
+					'content-type': 'text/plain',
+					authorization: 'bearer nope',
+					'x-other': 'omit'
+				}
+			})
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+		expect(attrs['http.request.header.x-allowed']).toBe('yes')
+		expect(attrs['http.request.header.content-type']).toBe('text/plain')
+		expect(attrs['http.request.header.authorization']).toBeUndefined()
+		expect(attrs['http.request.header.x-other']).toBeUndefined()
+	})
+
+	it('records raw Cookie header when allow-listed (http.request.cookie only with context.cookie)', async () => {
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					serviceName: 'cookie-allowlist',
+					spanRequestHeaders: ['cookie']
+				})
+			)
+			.get('/r', () => 'ok')
+
+		await app.handle(
+			new Request('http://localhost/r', {
+				headers: { cookie: 'a=1; b=2' }
+			})
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+		expect(attrs['http.request.header.cookie']).toBe('a=1; b=2')
+		expect(attrs['http.request.cookie']).toBeUndefined()
+	})
+
+	it('does not record cookie attributes when allow-listed but no Cookie header and no context.cookie', async () => {
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					serviceName: 'cookie-absent',
+					spanRequestHeaders: ['cookie']
+				})
+			)
+			.get('/r', () => 'ok')
+
+		await app.handle(new Request('http://localhost/r'))
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+		expect(attrs['http.request.header.cookie']).toBeUndefined()
+		expect(attrs['http.request.cookie']).toBeUndefined()
+	})
+
+	it('records only allow-listed response headers', async () => {
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					serviceName: 'resp-headers-allowlist',
+					spanResponseHeaders: ['x-out']
+				})
+			)
+			.onRequest(({ set }) => {
+				set.headers['X-Out'] = 'seen'
+				set.headers['X-Hidden'] = 'secret'
+			})
+			.get('/r', () => 'ok')
+
+		await app.handle(new Request('http://localhost/r'))
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+		expect(attrs['http.response.header.x-out']).toBe('seen')
+		expect(attrs['http.response.header.x-hidden']).toBeUndefined()
+	})
+})

--- a/test/span-privacy.test.ts
+++ b/test/span-privacy.test.ts
@@ -1,0 +1,216 @@
+import { Elysia } from 'elysia'
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test'
+import { trace } from '@opentelemetry/api'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+import {
+	InMemorySpanExporter,
+	SimpleSpanProcessor
+} from '@opentelemetry/sdk-trace-base'
+import { opentelemetry } from '../src'
+
+const flushSpans = () => new Promise((r) => setTimeout(r, 150))
+
+describe('Span privacy defaults (URL redaction, opt-in HTTP attributes)', () => {
+	let exporter: InMemorySpanExporter
+	let provider: NodeTracerProvider
+
+	beforeEach(() => {
+		trace.disable()
+		exporter = new InMemorySpanExporter()
+		provider = new NodeTracerProvider({
+			spanProcessors: [new SimpleSpanProcessor(exporter)]
+		})
+		provider.register()
+	})
+
+	afterEach(async () => {
+		await provider.shutdown()
+		trace.disable()
+	})
+
+	function rootSpan() {
+		return exporter.getFinishedSpans().find(
+			(s) => s.attributes['http.request.method'] !== undefined
+		)
+	}
+
+	it('redacts sensitive query params in url.full and url.query by default', async () => {
+		const app = new Elysia()
+			.use(opentelemetry({ serviceName: 'url-redact-default' }))
+			.get('/r', () => 'ok')
+
+		await app.handle(
+			new Request(
+				'http://localhost/r?q=safe&token=supersecret&password=x'
+			)
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+		const full = String(attrs['url.full'])
+		const q = String(attrs['url.query'])
+
+		expect(full).toContain('q=safe')
+		expect(full).not.toContain('supersecret')
+		expect(full).not.toContain('x')
+		expect(full).toContain('token=[REDACTED]')
+		expect(q).toContain('q=safe')
+		expect(q).not.toContain('supersecret')
+		expect(q).toContain('token=[REDACTED]')
+		expect(q).toContain('password=[REDACTED]')
+	})
+
+	it('does not redact query values when spanUrlRedaction is false', async () => {
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					serviceName: 'url-raw',
+					spanUrlRedaction: false
+				})
+			)
+			.get('/r', () => 'ok')
+
+		await app.handle(
+			new Request('http://localhost/r?token=not-redacted')
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		expect(String(root!.attributes['url.full'])).toContain(
+			'token=not-redacted'
+		)
+		expect(String(root!.attributes['url.query'])).toBe(
+			'token=not-redacted'
+		)
+	})
+
+	it('strips user:pass@ from url.full by default', async () => {
+		const app = new Elysia()
+			.use(opentelemetry({ serviceName: 'url-strip-creds' }))
+			.get('/r', () => 'ok')
+
+		await app.handle(new Request('http://alice:bob@localhost/r'))
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const full = String(root!.attributes['url.full'])
+		expect(full).not.toContain('alice')
+		expect(full).not.toContain('bob')
+		expect(full).toMatch(/localhost\/?/)
+	})
+
+	it('redacts custom sensitiveQueryParams alongside builtins', async () => {
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					serviceName: 'url-custom-keys',
+					spanUrlRedaction: { sensitiveQueryParams: ['X-My-Secret'] }
+				})
+			)
+			.get('/r', () => 'ok')
+
+		await app.handle(
+			new Request(
+				'http://localhost/r?q=safe&x-my-secret=hidden&token=also-hidden'
+			)
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const q = String(root!.attributes['url.query'])
+		expect(q).toContain('q=safe')
+		expect(q).toContain('x-my-secret=[REDACTED]')
+		expect(q).toContain('token=[REDACTED]')
+		expect(q).not.toContain('hidden')
+		expect(q).not.toContain('also-hidden')
+	})
+
+	it('preserves credentials when stripCredentials is false', async () => {
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					serviceName: 'url-keep-creds',
+					spanUrlRedaction: { stripCredentials: false }
+				})
+			)
+			.get('/r', () => 'ok')
+
+		await app.handle(
+			new Request('http://alice:bob@localhost/r?token=secret')
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const full = String(root!.attributes['url.full'])
+		expect(full).toContain('alice')
+		expect(full).toContain('bob')
+		expect(full).toContain('token=[REDACTED]')
+	})
+
+	it('does not record user_agent, content length, or body attributes without opt-in', async () => {
+		const app = new Elysia()
+			.use(opentelemetry({ serviceName: 'no-extra-http-attrs' }))
+			.post('/r', ({ body }) => body)
+
+		await app.handle(
+			new Request('http://localhost/r', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Content-Length': '9',
+					'user-agent': 'privacy-test-ua'
+				},
+				body: '{"a":123}'
+			})
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+		expect(attrs['user_agent.original']).toBeUndefined()
+		expect(attrs['http.request_content_length']).toBeUndefined()
+		expect(attrs['http.request.body.size']).toBeUndefined()
+		expect(attrs['http.request.body']).toBeUndefined()
+		expect(attrs['http.response.body.size']).toBeUndefined()
+		expect(attrs['http.response.body']).toBeUndefined()
+	})
+
+	it('records request body, response body, and sizes when opted in', async () => {
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					serviceName: 'opt-in-http-attrs',
+					spanRecordHttpExtras: true
+				})
+			)
+			.post('/r', ({ body }) => body)
+
+		await app.handle(
+			new Request('http://localhost/r', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Content-Length': '9',
+					'user-agent': 'opt-in-ua'
+				},
+				body: '{"a":123}'
+			})
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+		expect(attrs['user_agent.original']).toBe('opt-in-ua')
+		expect(attrs['http.request_content_length']).toBe(9)
+		expect(attrs['http.request.body.size']).toBe(9)
+		expect(attrs['http.request.body']).toBe('{"a":123}')
+	})
+})

--- a/test/span-privacy.test.ts
+++ b/test/span-privacy.test.ts
@@ -153,9 +153,9 @@ describe('Span privacy defaults (URL redaction, opt-in HTTP attributes)', () => 
 		expect(full).toContain('token=[REDACTED]')
 	})
 
-	it('does not record user_agent, content length, or body attributes without opt-in', async () => {
+	it('always records user_agent.original and content-length by default', async () => {
 		const app = new Elysia()
-			.use(opentelemetry({ serviceName: 'no-extra-http-attrs' }))
+			.use(opentelemetry({ serviceName: 'always-on-attrs' }))
 			.post('/r', ({ body }) => body)
 
 		await app.handle(
@@ -164,7 +164,7 @@ describe('Span privacy defaults (URL redaction, opt-in HTTP attributes)', () => 
 				headers: {
 					'Content-Type': 'application/json',
 					'Content-Length': '9',
-					'user-agent': 'privacy-test-ua'
+					'user-agent': 'always-on-ua'
 				},
 				body: '{"a":123}'
 			})
@@ -174,20 +174,62 @@ describe('Span privacy defaults (URL redaction, opt-in HTTP attributes)', () => 
 		const root = rootSpan()
 		expect(root).toBeDefined()
 		const attrs = root!.attributes
-		expect(attrs['user_agent.original']).toBeUndefined()
-		expect(attrs['http.request_content_length']).toBeUndefined()
+		expect(attrs['user_agent.original']).toBe('always-on-ua')
+		expect(attrs['http.request_content_length']).toBe(9)
+	})
+
+	it('records Content-Length: 0 correctly', async () => {
+		const app = new Elysia()
+			.use(opentelemetry({ serviceName: 'content-length-zero' }))
+			.post('/r', () => 'ok')
+
+		await app.handle(
+			new Request('http://localhost/r', {
+				method: 'POST',
+				headers: {
+					'Content-Length': '0'
+				}
+			})
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		expect(root!.attributes['http.request_content_length']).toBe(0)
+	})
+
+	it('does not record body attributes without recordBody opt-in', async () => {
+		const app = new Elysia()
+			.use(opentelemetry({ serviceName: 'no-body-default' }))
+			.post('/r', ({ body }) => body)
+
+		await app.handle(
+			new Request('http://localhost/r', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Content-Length': '9'
+				},
+				body: '{"a":123}'
+			})
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
 		expect(attrs['http.request.body.size']).toBeUndefined()
 		expect(attrs['http.request.body']).toBeUndefined()
 		expect(attrs['http.response.body.size']).toBeUndefined()
 		expect(attrs['http.response.body']).toBeUndefined()
 	})
 
-	it('records request body, response body, and sizes when opted in', async () => {
+	it('records both request and response body when recordBody is true', async () => {
 		const app = new Elysia()
 			.use(
 				opentelemetry({
-					serviceName: 'opt-in-http-attrs',
-					spanRecordHttpExtras: true
+					serviceName: 'record-body-true',
+					recordBody: true
 				})
 			)
 			.post('/r', ({ body }) => body)
@@ -198,7 +240,7 @@ describe('Span privacy defaults (URL redaction, opt-in HTTP attributes)', () => 
 				headers: {
 					'Content-Type': 'application/json',
 					'Content-Length': '9',
-					'user-agent': 'opt-in-ua'
+					'user-agent': 'body-test-ua'
 				},
 				body: '{"a":123}'
 			})
@@ -208,9 +250,67 @@ describe('Span privacy defaults (URL redaction, opt-in HTTP attributes)', () => 
 		const root = rootSpan()
 		expect(root).toBeDefined()
 		const attrs = root!.attributes
-		expect(attrs['user_agent.original']).toBe('opt-in-ua')
-		expect(attrs['http.request_content_length']).toBe(9)
 		expect(attrs['http.request.body.size']).toBe(9)
 		expect(attrs['http.request.body']).toBe('{"a":123}')
+	})
+
+	it('records only request body when recordBody: { request: true }', async () => {
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					serviceName: 'record-body-request-only',
+					recordBody: { request: true }
+				})
+			)
+			.post('/r', ({ body }) => body)
+
+		await app.handle(
+			new Request('http://localhost/r', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Content-Length': '9'
+				},
+				body: '{"a":123}'
+			})
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+		expect(attrs['http.request.body.size']).toBe(9)
+		expect(attrs['http.request.body']).toBe('{"a":123}')
+		expect(attrs['http.response.body']).toBeUndefined()
+		expect(attrs['http.response.body.size']).toBeUndefined()
+	})
+
+	it('records only response body when recordBody: { response: true }', async () => {
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					serviceName: 'record-body-response-only',
+					recordBody: { response: true }
+				})
+			)
+			.post('/r', ({ body }) => body)
+
+		await app.handle(
+			new Request('http://localhost/r', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Content-Length': '9'
+				},
+				body: '{"a":123}'
+			})
+		)
+		await flushSpans()
+
+		const root = rootSpan()
+		expect(root).toBeDefined()
+		const attrs = root!.attributes
+		expect(attrs['http.request.body']).toBeUndefined()
+		expect(attrs['http.request.body.size']).toBeUndefined()
 	})
 })


### PR DESCRIPTION
Closes https://github.com/elysiajs/opentelemetry/issues/69

### Problem

The plugin recorded **all** request/response headers as span attributes with no filtering, meaning `Authorization`, `Cookie`, `Set-Cookie`, and arbitrary scanner headers ended up in exported traces. Beyond headers, body content was always emitted, and `url.full` / `url.query` could contain credentials or sensitive query parameters in cleartext.

This violated the [OTel HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/) guidance that instrumentations should only emit sanitized, non-sensitive attributes by default.

### Changes

#### 1. Opt-in header allow-lists (`headersToSpanAttributes`)

Named to align with the official [`@opentelemetry/instrumentation-http`](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http) option shape (server-only, so no `client`/`server` nesting):

```typescript
headersToSpanAttributes?: {
  requestHeaders?: string[]   // → http.request.header.<name>
  responseHeaders?: string[]  // → http.response.header.<name>
}
```

- Case-insensitive names. Default: **none** (no headers recorded).
- Use `"*"` in either list to capture **all** headers — useful for dev/debugging and as a one-line backwards-compatible migration path.
- Including `'cookie'` in `requestHeaders` records the raw `Cookie` header; `http.request.cookie` is only emitted when `'cookie'` is allow-listed **and** `context.cookie` is present.

#### 2. URL redaction (on by default)

- `spanUrlRedaction?: false | { stripCredentials?: boolean; sensitiveQueryParams?: string[] }`
- **Default (omitted):** redacts values of known sensitive query keys (`token`, `password`, `secret`, `api_key`, etc.) to `[REDACTED]` in `url.full` and `url.query`, and strips `user:pass@` credentials from `url.full`. Percent-encoded parameter names are decoded before comparison.
- `false`: disables all URL redaction (raw URLs recorded as-is).
- `{ stripCredentials: false }`: keeps credentials while still redacting query params.
- `{ sensitiveQueryParams: ['my-key'] }`: adds custom keys to the builtin set.

#### 3. Body recording opt-in (`recordBody`)

```typescript
recordBody?: boolean | { request?: boolean; response?: boolean }
```

- `true`: record both request and response body content (`http.request.body`, `http.response.body`, and their `.size` counterparts).
- `{ request: true }` or `{ response: true }`: record only one side.
- `false` / omitted (default): no body content recorded.

Body serialization is wrapped in a try/catch so circular structures or BigInt values produce `[Unserializable]` rather than crashing the tracing path.

#### 4. Always-on standard semconv attributes

`user_agent.original` and `http.request_content_length` are now **always emitted** when their respective headers are present — they're standard OTel semantic convention attributes and not sensitive. They no longer require any opt-in flag.

#### 5. Bug fix: `Content-Length: 0`

Fixed `if (number)` → `if (number !== null)` so that a valid parsed `Content-Length` of `0` is no longer silently dropped.

#### 6. Minor cleanup

- Removed duplicate `server.address` assignment.
- Removed leftover block scoping from refactored code.

### Tests

- `test/span-headers.test.ts` — default (no headers on span), allow-listed request/response headers, `"*"` wildcard for request and response, `user-agent` allow-list, cookie behavior, response header default.
- `test/span-privacy.test.ts` — URL redaction defaults, `spanUrlRedaction: false`, credential stripping, `stripCredentials: false`, custom `sensitiveQueryParams`, always-on `user_agent.original` and `http.request_content_length`, `Content-Length: 0` regression, body absent by default, `recordBody: true`, `recordBody: { request: true }`, `recordBody: { response: true }`.

### Breaking change

Callers that relied on **all** headers appearing on spans must now pass `headersToSpanAttributes: { requestHeaders: ['*'] }` (or an explicit list) for the headers they need. Body content now requires `recordBody: true`. `user_agent.original` and `http.request_content_length` remain always-on and require no configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable URL redaction (strip credentials, redact sensitive query values) and emit query only when present
  * Opt-in body recording for requests/responses with size/content serialization
  * Selective header-to-span-attribute capture with case-insensitive allow-lists, wildcard support, and explicit cookie opt-in

* **Tests**
  * Added tests validating header capture, cookie handling, URL redaction, and body-recording privacy controls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->