### PR TITLE
feat: add enabled option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto'
 new Elysia()
 	.use(
 		opentelemetry({
+			enabled: process.env.OTEL_ENABLED !== 'false',
+			serviceName: 'api',
 			spanProcessors: [
 				new BatchSpanProcessor(
 					new OTLPTraceExporter()
@@ -24,5 +26,26 @@ new Elysia()
 		})
 	)
 ```
+
+## Production defaults
+
+```typescript
+new Elysia()
+	.use(
+		opentelemetry({
+			enabled: process.env.OTEL_ENABLED !== 'false',
+			serviceName: process.env.OTEL_SERVICE_NAME ?? 'api',
+			recordBody: false,
+			headersToSpanAttributes: {
+				request: ['user-agent', 'content-type'],
+				response: ['content-type']
+			}
+		})
+	)
+```
+
+- Use `enabled: false` to keep the plugin in the app graph while skipping SDK and span setup.
+- Keep `recordBody` disabled unless request or response bodies are safe to export.
+- Allow-list headers instead of using `'*'` in production.
 
 See [documentation](https://elysiajs.com/plugins/opentelemetry.html) for more details.

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,11 @@ type OpenTeleMetryOptions = NonNullable<
  * however, this is a simple way to initialize OpenTelemetry SDK
  */
 export interface ElysiaOpenTelemetryOptions extends OpenTeleMetryOptions {
+	/**
+	 * Toggle the plugin without branching application composition.
+	 * `false`: return an inert Elysia plugin and skip SDK/span setup.
+	 */
+	enabled?: boolean
 	contextManager?: ContextManager
 	/**
 	 * Optional function to determine whether a given request should be traced.
@@ -329,6 +334,7 @@ export const setAttributes = (attributes: Attributes) =>
 	!!getCurrentSpan()?.setAttributes(attributes)
 
 export const opentelemetry = ({
+	enabled = true,
 	serviceName = 'Elysia',
 	instrumentations,
 	contextManager,
@@ -338,6 +344,8 @@ export const opentelemetry = ({
 	headersToSpanAttributes,
 	...options
 }: ElysiaOpenTelemetryOptions = {}) => {
+	if (!enabled) return new Elysia({ name: '@elysia/opentelemetry' })
+
 	const spanRequestHeaderSet = toHeaderNameSet(
 		headersToSpanAttributes?.request
 	)

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -28,6 +28,32 @@ describe('Core OpenTelemetry Plugin', () => {
 		}
 	})
 
+	it('should not start tracing when disabled', async () => {
+		trace.disable()
+
+		let activeSpan: unknown
+		const app = new Elysia()
+			.use(
+				opentelemetry({
+					enabled: false,
+					serviceName: 'disabled-test'
+				})
+			)
+			.get('/disabled', () => {
+				activeSpan = trace.getActiveSpan()
+
+				return 'ok'
+			})
+
+		expect(shouldStartNodeSDK(trace.getTracerProvider())).toBe(true)
+
+		const response = await app.handle(req('/disabled'))
+
+		expect(response.status).toBe(200)
+		expect(await response.text()).toBe('ok')
+		expect(activeSpan).toBeUndefined()
+	})
+
 	it('should initialize plugin without options', () => {
 		expect(typeof opentelemetry).toBe('function')
 


### PR DESCRIPTION
## Summary
- add an `enabled` option to keep plugin composition stable while disabling telemetry setup
- skip SDK/span setup entirely when `enabled: false`
- document a production-friendly setup with env gating, body capture disabled, and header allow-lists

Closes #79

## Behavior

```ts
new Elysia().use(
  opentelemetry({
    enabled: process.env.OTEL_ENABLED !== "false",
    serviceName: "api"
  })
)
```

When disabled, the plugin returns an inert Elysia plugin with the same name and does not start the NodeSDK or register trace hooks.

## Tests
- `bun test --preload ./test/test-setup.ts test/core.test.ts`
- `bun run build`
- `npm run test:node`
- `bun test --preload ./test/test-setup.ts` currently reaches 62 passing tests, then fails on existing `test/integration.test.ts` import: `Cannot find module @elysiajs/eden` while package.json depends on `@elysia/eden`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `enabled` option to toggle the OpenTelemetry plugin on/off for flexible deployment control

* **Documentation**
  * Added production defaults guidance with configuration examples and best-practice recommendations for secure production deployments, including recommendations for body recording settings, header filtering strategies, and environment-based configuration approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->