### PR TITLE
fix: incorrect `span.end()` calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ const createActiveSpanHandler = (fn: (span: Span) => unknown) =>
 				// @ts-ignore
 				return Promise.resolve(result).then(
 					(value) => {
-						span.end()
+						if (span.isRecording()) span.end()
 						return value
 					},
 					(rejectResult) => {
@@ -151,12 +151,12 @@ const createActiveSpanHandler = (fn: (span: Span) => unknown) =>
 						})
 
 						span.recordException(rejectResult)
-						span.end()
+						if (span.isRecording()) span.end()
 						throw rejectResult
 					}
 				)
 
-			span.end()
+			if (span.isRecording()) span.end()
 			return result
 		} catch (error) {
 			const err = error as Error
@@ -166,7 +166,7 @@ const createActiveSpanHandler = (fn: (span: Span) => unknown) =>
 				message: err?.message
 			})
 			span.recordException(err)
-			span.end()
+			if (span.isRecording()) span.end()
 
 			throw error
 		}

--- a/test/span-nested.test.ts
+++ b/test/span-nested.test.ts
@@ -8,7 +8,7 @@ describe('Nested Spans', () => {
 	const diagError = spyOn(diag, 'error')
 
 	beforeEach(() => {
-		diagError.mockRestore()
+		diagError.mockClear()
 	})
 
 	it('should not call end() twice on nested record() spans', async () => {

--- a/test/span-nested.test.ts
+++ b/test/span-nested.test.ts
@@ -1,0 +1,33 @@
+import { Elysia } from 'elysia'
+import { describe, expect, it, spyOn, beforeEach } from 'bun:test'
+import { opentelemetry, record } from '../src'
+import { diag } from '@opentelemetry/api'
+import { req } from './test-setup'
+
+describe('Nested Spans', () => {
+	const diagError = spyOn(diag, 'error')
+
+	beforeEach(() => {
+		diagError.mockRestore()
+	})
+
+	it('should not call end() twice on nested record() spans', async () => {
+		const app = new Elysia()
+			.use(opentelemetry({ serviceName: 'double-end-test' }))
+			.get('/', async () => {
+				return record('parent', async () => {
+					await record('child1', async () => {
+						await new Promise((res) => setTimeout(res, 10))
+					})
+					await record('child2', async () => {
+						await new Promise((res) => setTimeout(res, 10))
+					})
+					return 'ok'
+				})
+			})
+
+		const response = await app.handle(req('/'))
+		expect(response.status).toBe(200)
+		expect(diagError.mock.calls).toEqual([])
+	})
+})


### PR DESCRIPTION
When a span is ended, `createActiveSpanHandler` would still call `span.end()` triggering a error:

```
child1 cd812d135e895becfcbd2a4ca8a76fef-7a423a8511a1e52b - You can only call end() on a span once.
child2 cd812d135e895becfcbd2a4ca8a76fef-5a8e39e0e043740b - You can only call end() on a span once.
parent cd812d135e895becfcbd2a4ca8a76fef-96a859b5306fcc92 - You can only call end() on a span once.
```

I added a guard for every `span.end()` call to prevent this behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracing span lifecycle management to avoid attempting to end spans that have already finished.
  * Ensured nested tracing spans behave correctly without triggering double-end/tracing errors, while preserving existing success and error outcomes.

* **Tests**
  * Added a nested spans test to confirm requests return successfully and no tracing errors are reported when child spans are recorded within a parent span.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->